### PR TITLE
Prevent warning with bad server data

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -18,7 +18,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             $method = $server['REQUEST_METHOD'];
         }
 
-        if (null === $method) {
+        if (empty($method)) {
             throw new \InvalidArgumentException('Cannot determine HTTP method');
         }
 


### PR DESCRIPTION
If `$server` does not contain the method, a warning would be thrown
because of undefined `$method`.