### PR TITLE
Allow guzzlehttp/psr7=^2.0, while retaining BC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "psr/http-factory": "^1.0",
-        "guzzlehttp/psr7": "^1.4.2"
+        "guzzlehttp/psr7": "^1.4.2||^2.0"
     },
     "require-dev": {
         "http-interop/http-factory-tests": "^0.9",

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -2,25 +2,44 @@
 
 namespace Http\Factory\Guzzle;
 
+use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+
+use function GuzzleHttp\Psr7\stream_for;
+use function GuzzleHttp\Psr7\try_fopen;
 
 class StreamFactory implements StreamFactoryInterface
 {
     public function createStream(string $content = ''): StreamInterface
     {
-        return \GuzzleHttp\Psr7\stream_for($content);
+        if (\function_exists('stream_for')) {
+            // fallback for guzzlehttp/psr7<1.7.0
+            return stream_for($content);
+        }
+        return Utils::streamFor($content);
     }
 
     public function createStreamFromFile(string $file, string $mode = 'r'): StreamInterface
     {
-        $resource = \GuzzleHttp\Psr7\try_fopen($file, $mode);
+        if (\function_exists('try_fopen') && \function_exists('steam_for')) {
+            // fallback for guzzlehttp/psr7<1.7.0
+            $resource = try_fopen($file, $mode);
 
-        return \GuzzleHttp\Psr7\stream_for($resource);
+            return stream_for($resource);
+        }
+        $resource = Utils::tryFopen($file, $mode);
+
+        return new Stream($resource);
     }
 
     public function createStreamFromResource($resource): StreamInterface
     {
-        return \GuzzleHttp\Psr7\stream_for($resource);
+        if (\function_exists('stream_for')) {
+            // fallback for guzzlehttp/psr7<1.7.0
+            return stream_for($resource);
+        }
+        return new Stream($resource);
     }
 }


### PR DESCRIPTION
Hi, recently `guzzlehttp/psr7` received a major version upgrade. Not much has changed, but I updated this lib (with backwards compatibility in mind) to also be able to use `guzzlehttp/psr7=^2.0`