### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/UploadedFileFactory.php
+++ b/src/UploadedFileFactory.php
@@ -11,10 +11,10 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
 {
     public function createUploadedFile(
         StreamInterface $stream,
-        int $size = null,
+        ?int $size = null,
         int $error = \UPLOAD_ERR_OK,
-        string $clientFilename = null,
-        string $clientMediaType = null
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null
     ): UploadedFileInterface {
         if ($size === null) {
             $size = $stream->getSize();


### PR DESCRIPTION
Fixes for implicit nullability deprecation.
When executed in PHP 8.4, it will trigger a warning as E_DEPRECATED.

I would appreciate it if you could approve the PR and release the new version.